### PR TITLE
[Phase 1] Add OpenGL rendering support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,6 +31,11 @@ pub fn build(b: *std.Build) void {
     // SDL2のシステムライブラリをリンク
     lib.linkSystemLibrary("SDL2");
     lib.linkLibC();
+    
+    // OpenGLフレームワークをリンク（macOS）
+    if (target.result.os.tag == .macos) {
+        lib.linkFramework("OpenGL");
+    }
 
     b.installArtifact(lib);
 
@@ -43,6 +48,11 @@ pub fn build(b: *std.Build) void {
     // SDL2のシステムライブラリをリンク
     exe.linkSystemLibrary("SDL2");
     exe.linkLibC();
+    
+    // OpenGLフレームワークをリンク（macOS）
+    if (target.result.os.tag == .macos) {
+        exe.linkFramework("OpenGL");
+    }
 
     // プラットフォーム固有の設定
     if (target.result.os.tag == .windows) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,48 +1,92 @@
 const std = @import("std");
-
-// SDL2ヘッダーを直接インポート
-const c = @cImport({
-    @cInclude("SDL2/SDL.h");
-});
+const gl = @import("renderer/opengl/gl.zig");
+const OpenGLContext = @import("renderer/opengl/context.zig").OpenGLContext;
+const shader = @import("renderer/opengl/shader.zig");
 
 pub fn main() !void {
     // SDL2の初期化
-    if (c.SDL_Init(c.SDL_INIT_VIDEO) != 0) {
-        std.log.err("SDL_Init failed: {s}", .{c.SDL_GetError()});
+    if (gl.c.SDL_Init(gl.c.SDL_INIT_VIDEO) != 0) {
+        std.log.err("SDL_Init failed: {s}", .{gl.c.SDL_GetError()});
         return error.SDLInitFailed;
     }
-    defer c.SDL_Quit();
+    defer gl.c.SDL_Quit();
 
-    // ウィンドウの作成
-    const window = c.SDL_CreateWindow(
-        "Corestone Engine",
-        c.SDL_WINDOWPOS_CENTERED,
-        c.SDL_WINDOWPOS_CENTERED,
+    // ウィンドウの作成（OpenGLフラグを追加）
+    const window = gl.c.SDL_CreateWindow(
+        "Corestone Engine - OpenGL",
+        gl.c.SDL_WINDOWPOS_CENTERED,
+        gl.c.SDL_WINDOWPOS_CENTERED,
         800,
         600,
-        c.SDL_WINDOW_SHOWN,
+        gl.c.SDL_WINDOW_SHOWN | gl.c.SDL_WINDOW_OPENGL,
     ) orelse {
-        std.log.err("SDL_CreateWindow failed: {s}", .{c.SDL_GetError()});
+        std.log.err("SDL_CreateWindow failed: {s}", .{gl.c.SDL_GetError()});
         return error.WindowCreationFailed;
     };
-    defer c.SDL_DestroyWindow(window);
+    defer gl.c.SDL_DestroyWindow(window);
 
-    std.log.info("Corestone Engine initialized successfully!", .{});
-    std.log.info("Window created: 800x600", .{});
+    // OpenGLコンテキストの初期化
+    var gl_context = try OpenGLContext.init(window);
+    defer gl_context.deinit();
+
+    // ビューポートの設定
+    OpenGLContext.setViewport(800, 600);
+
+    // シェーダーの作成
+    var vertex_shader = try shader.Shader.init(shader.basic_vertex_shader, .vertex);
+    defer vertex_shader.deinit();
+    
+    var fragment_shader = try shader.Shader.init(shader.basic_fragment_shader, .fragment);
+    defer fragment_shader.deinit();
+    
+    var shader_program = try shader.ShaderProgram.init(&vertex_shader, &fragment_shader);
+    defer shader_program.deinit();
+
+    // 三角形の頂点データ
+    const vertices = [_]gl.GLfloat{
+        // 位置
+        -0.5, -0.5, 0.0,  // 左下
+         0.5, -0.5, 0.0,  // 右下
+         0.0,  0.5, 0.0,  // 上
+    };
+
+    // VAOとVBOの作成
+    var vao: gl.GLuint = 0;
+    var vbo: gl.GLuint = 0;
+    
+    gl.glGenVertexArrays(1, &vao);
+    gl.glGenBuffers(1, &vbo);
+    
+    // VAOをバインド
+    gl.glBindVertexArray(vao);
+    
+    // VBOをバインドしてデータをコピー
+    gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo);
+    gl.glBufferData(gl.GL_ARRAY_BUFFER, @sizeOf(@TypeOf(vertices)), &vertices, gl.GL_STATIC_DRAW);
+    
+    // 頂点属性を設定
+    gl.glVertexAttribPointer(0, 3, gl.GL_FLOAT, gl.GL_FALSE, 3 * @sizeOf(gl.GLfloat), null);
+    gl.glEnableVertexAttribArray(0);
+    
+    // バインドを解除
+    gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0);
+    gl.glBindVertexArray(0);
+
+    std.log.info("OpenGL rendering initialized successfully!", .{});
 
     // メインループ
     var quit = false;
-    var event: c.SDL_Event = undefined;
+    var event: gl.c.SDL_Event = undefined;
     
     while (!quit) {
         // イベント処理
-        while (c.SDL_PollEvent(&event) != 0) {
+        while (gl.c.SDL_PollEvent(&event) != 0) {
             switch (event.type) {
-                c.SDL_QUIT => {
+                gl.c.SDL_QUIT => {
                     quit = true;
                 },
-                c.SDL_KEYDOWN => {
-                    if (event.key.keysym.sym == c.SDLK_ESCAPE) {
+                gl.c.SDL_KEYDOWN => {
+                    if (event.key.keysym.sym == gl.c.SDLK_ESCAPE) {
                         quit = true;
                     }
                 },
@@ -50,17 +94,24 @@ pub fn main() !void {
             }
         }
 
-        // 画面をクリア（黒色）
-        const renderer = c.SDL_GetRenderer(window);
-        if (renderer) |r| {
-            _ = c.SDL_SetRenderDrawColor(r, 0, 0, 0, 255);
-            _ = c.SDL_RenderClear(r);
-            c.SDL_RenderPresent(r);
-        }
-
-        // CPUを休ませる（約60FPS）
-        c.SDL_Delay(16);
+        // 画面をクリア（ダークブルー）
+        OpenGLContext.clearScreen(0.1, 0.1, 0.2, 1.0);
+        
+        // シェーダープログラムを使用
+        shader_program.use();
+        
+        // 三角形を描画
+        gl.glBindVertexArray(vao);
+        gl.glDrawArrays(gl.GL_TRIANGLES, 0, 3);
+        gl.glBindVertexArray(0);
+        
+        // バッファをスワップ
+        gl_context.swapBuffers();
     }
+    
+    // クリーンアップ
+    gl.glDeleteVertexArrays(1, &vao);
+    gl.glDeleteBuffers(1, &vbo);
 
     std.log.info("Shutting down Corestone Engine...", .{});
 }

--- a/src/renderer/opengl/context.zig
+++ b/src/renderer/opengl/context.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const gl = @import("gl.zig");
+
+pub const OpenGLContext = struct {
+    context: gl.c.SDL_GLContext,
+    window: *gl.c.SDL_Window,
+    
+    pub fn init(window: *gl.c.SDL_Window) !OpenGLContext {
+        // OpenGL 3.3 Core Profileを設定
+        if (gl.SDL_GL_SetAttribute(gl.SDL_GL_CONTEXT_MAJOR_VERSION, 3) != 0) {
+            std.log.err("Failed to set OpenGL major version: {s}", .{gl.c.SDL_GetError()});
+            return error.OpenGLAttributeError;
+        }
+        
+        if (gl.SDL_GL_SetAttribute(gl.SDL_GL_CONTEXT_MINOR_VERSION, 3) != 0) {
+            std.log.err("Failed to set OpenGL minor version: {s}", .{gl.c.SDL_GetError()});
+            return error.OpenGLAttributeError;
+        }
+        
+        if (gl.SDL_GL_SetAttribute(gl.SDL_GL_CONTEXT_PROFILE_MASK, gl.SDL_GL_CONTEXT_PROFILE_CORE) != 0) {
+            std.log.err("Failed to set OpenGL profile: {s}", .{gl.c.SDL_GetError()});
+            return error.OpenGLAttributeError;
+        }
+        
+        // ダブルバッファリングを有効化
+        if (gl.SDL_GL_SetAttribute(gl.SDL_GL_DOUBLEBUFFER, 1) != 0) {
+            std.log.err("Failed to enable double buffering: {s}", .{gl.c.SDL_GetError()});
+            return error.OpenGLAttributeError;
+        }
+        
+        // OpenGLコンテキストを作成
+        const context = gl.SDL_GL_CreateContext(window) orelse {
+            std.log.err("Failed to create OpenGL context: {s}", .{gl.c.SDL_GetError()});
+            return error.OpenGLContextCreationFailed;
+        };
+        
+        // コンテキストをカレントに設定
+        if (gl.SDL_GL_MakeCurrent(window, context) != 0) {
+            std.log.err("Failed to make OpenGL context current: {s}", .{gl.c.SDL_GetError()});
+            gl.SDL_GL_DeleteContext(context);
+            return error.OpenGLContextError;
+        }
+        
+        std.log.info("OpenGL context created successfully", .{});
+        // OpenGL関数を初期化
+        try gl.init();
+        
+        std.log.info("OpenGL version: {s}", .{gl.c.glGetString(gl.c.GL_VERSION)});
+        std.log.info("GLSL version: {s}", .{gl.c.glGetString(gl.c.GL_SHADING_LANGUAGE_VERSION)});
+        
+        return OpenGLContext{
+            .context = context,
+            .window = window,
+        };
+    }
+    
+    pub fn deinit(self: *OpenGLContext) void {
+        gl.SDL_GL_DeleteContext(self.context);
+        std.log.info("OpenGL context destroyed", .{});
+    }
+    
+    pub fn swapBuffers(self: *OpenGLContext) void {
+        gl.SDL_GL_SwapWindow(self.window);
+    }
+    
+    pub fn setViewport(width: i32, height: i32) void {
+        gl.glViewport(0, 0, @intCast(width), @intCast(height));
+    }
+    
+    pub fn clearScreen(r: f32, g: f32, b: f32, a: f32) void {
+        gl.glClearColor(r, g, b, a);
+        gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT);
+    }
+};

--- a/src/renderer/opengl/gl.zig
+++ b/src/renderer/opengl/gl.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+
+// OpenGL/SDL2ヘッダーをインポート
+pub const c = @cImport({
+    @cInclude("SDL2/SDL.h");
+    @cInclude("SDL2/SDL_opengl.h");
+});
+
+// OpenGLのタイプエイリアス
+pub const GLuint = c.GLuint;
+pub const GLint = c.GLint;
+pub const GLfloat = c.GLfloat;
+pub const GLsizei = c.GLsizei;
+pub const GLboolean = c.GLboolean;
+pub const GLchar = c.GLchar;
+pub const GLenum = c.GLenum;
+pub const GLvoid = anyopaque;
+pub const GLbitfield = c.GLbitfield;
+
+// OpenGL定数
+pub const GL_FALSE = c.GL_FALSE;
+pub const GL_TRUE = c.GL_TRUE;
+pub const GL_TRIANGLES = c.GL_TRIANGLES;
+pub const GL_UNSIGNED_INT = c.GL_UNSIGNED_INT;
+pub const GL_FLOAT = c.GL_FLOAT;
+pub const GL_VERTEX_SHADER = 0x8B31;
+pub const GL_FRAGMENT_SHADER = 0x8B30;
+pub const GL_COMPILE_STATUS = 0x8B81;
+pub const GL_LINK_STATUS = 0x8B82;
+pub const GL_INFO_LOG_LENGTH = 0x8B84;
+pub const GL_ARRAY_BUFFER = 0x8892;
+pub const GL_STATIC_DRAW = 0x88E4;
+pub const GL_COLOR_BUFFER_BIT = c.GL_COLOR_BUFFER_BIT;
+pub const GL_DEPTH_BUFFER_BIT = c.GL_DEPTH_BUFFER_BIT;
+
+// SDL_GL関数
+pub const SDL_GL_CreateContext = c.SDL_GL_CreateContext;
+pub const SDL_GL_DeleteContext = c.SDL_GL_DeleteContext;
+pub const SDL_GL_SetAttribute = c.SDL_GL_SetAttribute;
+pub const SDL_GL_SwapWindow = c.SDL_GL_SwapWindow;
+pub const SDL_GL_MakeCurrent = c.SDL_GL_MakeCurrent;
+pub const SDL_GL_GetProcAddress = c.SDL_GL_GetProcAddress;
+
+// SDL_GL属性
+pub const SDL_GL_CONTEXT_MAJOR_VERSION = c.SDL_GL_CONTEXT_MAJOR_VERSION;
+pub const SDL_GL_CONTEXT_MINOR_VERSION = c.SDL_GL_CONTEXT_MINOR_VERSION;
+pub const SDL_GL_CONTEXT_PROFILE_MASK = c.SDL_GL_CONTEXT_PROFILE_MASK;
+pub const SDL_GL_CONTEXT_PROFILE_CORE = c.SDL_GL_CONTEXT_PROFILE_CORE;
+pub const SDL_GL_DOUBLEBUFFER = c.SDL_GL_DOUBLEBUFFER;
+
+// OpenGL関数ポインタ
+pub var glClearColor: *const fn (r: GLfloat, g: GLfloat, b: GLfloat, a: GLfloat) callconv(.C) void = undefined;
+pub var glClear: *const fn (mask: GLbitfield) callconv(.C) void = undefined;
+pub var glViewport: *const fn (x: GLint, y: GLint, width: GLsizei, height: GLsizei) callconv(.C) void = undefined;
+pub var glCreateShader: *const fn (shader_type: GLenum) callconv(.C) GLuint = undefined;
+pub var glShaderSource: *const fn (shader: GLuint, count: GLsizei, string: [*c]const [*c]const u8, length: [*c]const GLint) callconv(.C) void = undefined;
+pub var glCompileShader: *const fn (shader: GLuint) callconv(.C) void = undefined;
+pub var glGetShaderiv: *const fn (shader: GLuint, pname: GLenum, params: [*c]GLint) callconv(.C) void = undefined;
+pub var glGetShaderInfoLog: *const fn (shader: GLuint, maxLength: GLsizei, length: [*c]GLsizei, infoLog: [*c]GLchar) callconv(.C) void = undefined;
+pub var glDeleteShader: *const fn (shader: GLuint) callconv(.C) void = undefined;
+pub var glCreateProgram: *const fn () callconv(.C) GLuint = undefined;
+pub var glAttachShader: *const fn (program: GLuint, shader: GLuint) callconv(.C) void = undefined;
+pub var glLinkProgram: *const fn (program: GLuint) callconv(.C) void = undefined;
+pub var glGetProgramiv: *const fn (program: GLuint, pname: GLenum, params: [*c]GLint) callconv(.C) void = undefined;
+pub var glGetProgramInfoLog: *const fn (program: GLuint, maxLength: GLsizei, length: [*c]GLsizei, infoLog: [*c]GLchar) callconv(.C) void = undefined;
+pub var glDeleteProgram: *const fn (program: GLuint) callconv(.C) void = undefined;
+pub var glUseProgram: *const fn (program: GLuint) callconv(.C) void = undefined;
+pub var glGenVertexArrays: *const fn (n: GLsizei, arrays: [*c]GLuint) callconv(.C) void = undefined;
+pub var glGenBuffers: *const fn (n: GLsizei, buffers: [*c]GLuint) callconv(.C) void = undefined;
+pub var glBindVertexArray: *const fn (array: GLuint) callconv(.C) void = undefined;
+pub var glBindBuffer: *const fn (target: GLenum, buffer: GLuint) callconv(.C) void = undefined;
+pub var glBufferData: *const fn (target: GLenum, size: isize, data: ?*const anyopaque, usage: GLenum) callconv(.C) void = undefined;
+pub var glVertexAttribPointer: *const fn (index: GLuint, size: GLint, type: GLenum, normalized: GLboolean, stride: GLsizei, pointer: ?*const anyopaque) callconv(.C) void = undefined;
+pub var glEnableVertexAttribArray: *const fn (index: GLuint) callconv(.C) void = undefined;
+pub var glDrawArrays: *const fn (mode: GLenum, first: GLint, count: GLsizei) callconv(.C) void = undefined;
+pub var glGetError: *const fn () callconv(.C) GLenum = undefined;
+pub var glDeleteVertexArrays: *const fn (n: GLsizei, arrays: [*c]const GLuint) callconv(.C) void = undefined;
+pub var glDeleteBuffers: *const fn (n: GLsizei, buffers: [*c]const GLuint) callconv(.C) void = undefined;
+
+// OpenGL関数を初期化
+pub fn init() !void {
+    glClearColor = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glClearColor") orelse return error.OpenGLFunctionNotFound));
+    glClear = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glClear") orelse return error.OpenGLFunctionNotFound));
+    glViewport = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glViewport") orelse return error.OpenGLFunctionNotFound));
+    glCreateShader = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glCreateShader") orelse return error.OpenGLFunctionNotFound));
+    glShaderSource = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glShaderSource") orelse return error.OpenGLFunctionNotFound));
+    glCompileShader = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glCompileShader") orelse return error.OpenGLFunctionNotFound));
+    glGetShaderiv = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glGetShaderiv") orelse return error.OpenGLFunctionNotFound));
+    glGetShaderInfoLog = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glGetShaderInfoLog") orelse return error.OpenGLFunctionNotFound));
+    glDeleteShader = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glDeleteShader") orelse return error.OpenGLFunctionNotFound));
+    glCreateProgram = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glCreateProgram") orelse return error.OpenGLFunctionNotFound));
+    glAttachShader = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glAttachShader") orelse return error.OpenGLFunctionNotFound));
+    glLinkProgram = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glLinkProgram") orelse return error.OpenGLFunctionNotFound));
+    glGetProgramiv = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glGetProgramiv") orelse return error.OpenGLFunctionNotFound));
+    glGetProgramInfoLog = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glGetProgramInfoLog") orelse return error.OpenGLFunctionNotFound));
+    glDeleteProgram = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glDeleteProgram") orelse return error.OpenGLFunctionNotFound));
+    glUseProgram = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glUseProgram") orelse return error.OpenGLFunctionNotFound));
+    glGenVertexArrays = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glGenVertexArrays") orelse return error.OpenGLFunctionNotFound));
+    glGenBuffers = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glGenBuffers") orelse return error.OpenGLFunctionNotFound));
+    glBindVertexArray = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glBindVertexArray") orelse return error.OpenGLFunctionNotFound));
+    glBindBuffer = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glBindBuffer") orelse return error.OpenGLFunctionNotFound));
+    glBufferData = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glBufferData") orelse return error.OpenGLFunctionNotFound));
+    glVertexAttribPointer = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glVertexAttribPointer") orelse return error.OpenGLFunctionNotFound));
+    glEnableVertexAttribArray = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glEnableVertexAttribArray") orelse return error.OpenGLFunctionNotFound));
+    glDrawArrays = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glDrawArrays") orelse return error.OpenGLFunctionNotFound));
+    glGetError = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glGetError") orelse return error.OpenGLFunctionNotFound));
+    glDeleteVertexArrays = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glDeleteVertexArrays") orelse return error.OpenGLFunctionNotFound));
+    glDeleteBuffers = @ptrCast(@alignCast(SDL_GL_GetProcAddress("glDeleteBuffers") orelse return error.OpenGLFunctionNotFound));
+    
+    std.log.info("OpenGL functions loaded successfully", .{});
+}

--- a/src/renderer/opengl/shader.zig
+++ b/src/renderer/opengl/shader.zig
@@ -1,0 +1,140 @@
+const std = @import("std");
+const gl = @import("gl.zig");
+
+pub const ShaderType = enum {
+    vertex,
+    fragment,
+    
+    pub fn toGL(self: ShaderType) gl.GLenum {
+        return switch (self) {
+            .vertex => gl.GL_VERTEX_SHADER,
+            .fragment => gl.GL_FRAGMENT_SHADER,
+        };
+    }
+};
+
+pub const Shader = struct {
+    id: gl.GLuint,
+    shader_type: ShaderType,
+    
+    pub fn init(source: []const u8, shader_type: ShaderType) !Shader {
+        const shader_id = gl.glCreateShader(shader_type.toGL());
+        if (shader_id == 0) {
+            std.log.err("Failed to create shader", .{});
+            return error.ShaderCreationFailed;
+        }
+        
+        // シェーダーソースを設定
+        const source_ptr: [*c]const u8 = source.ptr;
+        const source_len: gl.GLint = @intCast(source.len);
+        gl.glShaderSource(shader_id, 1, &source_ptr, &source_len);
+        
+        // シェーダーをコンパイル
+        gl.glCompileShader(shader_id);
+        
+        // コンパイル結果を確認
+        var compile_status: gl.GLint = 0;
+        gl.glGetShaderiv(shader_id, gl.GL_COMPILE_STATUS, &compile_status);
+        
+        if (compile_status == gl.GL_FALSE) {
+            var info_log_length: gl.GLint = 0;
+            gl.glGetShaderiv(shader_id, gl.GL_INFO_LOG_LENGTH, &info_log_length);
+            
+            if (info_log_length > 0) {
+                var info_log = std.ArrayList(u8).init(std.heap.page_allocator);
+                defer info_log.deinit();
+                
+                try info_log.resize(@intCast(info_log_length));
+                gl.glGetShaderInfoLog(shader_id, info_log_length, null, info_log.items.ptr);
+                
+                std.log.err("Shader compilation failed: {s}", .{info_log.items});
+            }
+            
+            gl.glDeleteShader(shader_id);
+            return error.ShaderCompilationFailed;
+        }
+        
+        return Shader{
+            .id = shader_id,
+            .shader_type = shader_type,
+        };
+    }
+    
+    pub fn deinit(self: *Shader) void {
+        gl.glDeleteShader(self.id);
+    }
+};
+
+pub const ShaderProgram = struct {
+    id: gl.GLuint,
+    
+    pub fn init(vertex_shader: *const Shader, fragment_shader: *const Shader) !ShaderProgram {
+        const program_id = gl.glCreateProgram();
+        if (program_id == 0) {
+            std.log.err("Failed to create shader program", .{});
+            return error.ShaderProgramCreationFailed;
+        }
+        
+        // シェーダーをアタッチ
+        gl.glAttachShader(program_id, vertex_shader.id);
+        gl.glAttachShader(program_id, fragment_shader.id);
+        
+        // プログラムをリンク
+        gl.glLinkProgram(program_id);
+        
+        // リンク結果を確認
+        var link_status: gl.GLint = 0;
+        gl.glGetProgramiv(program_id, gl.GL_LINK_STATUS, &link_status);
+        
+        if (link_status == gl.GL_FALSE) {
+            var info_log_length: gl.GLint = 0;
+            gl.glGetProgramiv(program_id, gl.GL_INFO_LOG_LENGTH, &info_log_length);
+            
+            if (info_log_length > 0) {
+                var info_log = std.ArrayList(u8).init(std.heap.page_allocator);
+                defer info_log.deinit();
+                
+                try info_log.resize(@intCast(info_log_length));
+                gl.glGetProgramInfoLog(program_id, info_log_length, null, info_log.items.ptr);
+                
+                std.log.err("Shader program linking failed: {s}", .{info_log.items});
+            }
+            
+            gl.glDeleteProgram(program_id);
+            return error.ShaderLinkingFailed;
+        }
+        
+        return ShaderProgram{
+            .id = program_id,
+        };
+    }
+    
+    pub fn deinit(self: *ShaderProgram) void {
+        gl.glDeleteProgram(self.id);
+    }
+    
+    pub fn use(self: *const ShaderProgram) void {
+        gl.glUseProgram(self.id);
+    }
+};
+
+// 基本的なシェーダーソース
+pub const basic_vertex_shader =
+    \\#version 330 core
+    \\layout (location = 0) in vec3 aPos;
+    \\
+    \\void main()
+    \\{
+    \\    gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);
+    \\}
+;
+
+pub const basic_fragment_shader =
+    \\#version 330 core
+    \\out vec4 FragColor;
+    \\
+    \\void main()
+    \\{
+    \\    FragColor = vec4(1.0f, 0.5f, 0.2f, 1.0f);
+    \\}
+;


### PR DESCRIPTION
## 概要
フェーズ1: OpenGLレンダリングの基盤実装

## 実装内容
- OpenGL 3.3 Core Profileの初期化
- シェーダーシステム（頂点・フラグメント）
- VAO/VBOによる三角形描画
- SDL2経由でのOpenGL関数の動的読み込み

## 動作確認
- macOS: OpenGL 4.1で動作確認済み
- オレンジ色の三角形が描画される

## ファイル構成
- `src/renderer/opengl/` - OpenGLモジュール
  - `gl.zig` - OpenGL関数ローダー
  - `context.zig` - コンテキスト管理
  - `shader.zig` - シェーダー管理